### PR TITLE
feat : 구글 로그인 기능 (#13)

### DIFF
--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/GoogleApiClient.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/GoogleApiClient.java
@@ -1,4 +1,55 @@
 package com.be.squeak_squeak.member.oauth.google;
 
+import com.be.squeak_squeak.member.oauth.google.dto.GoogleAccessTokenRes;
+import com.be.squeak_squeak.member.oauth.google.dto.GoogleMemberInfoRes;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
 public class GoogleApiClient {
+
+    @Value("${google.member-info-url}")
+    private String GOOGLE_MEMBER_INFO_URL;
+    @Value("${google.access-token-url}")
+    private String GOOGLE_ACCESS_TOKEN_URL;
+    @Value("${google.client-id}")
+    private String GOOGLE_CLIENT_ID;
+    @Value("${google.secret-id}")
+    private String GOOGLE_SECRET_ID;
+    @Value("${google.redirect-uri}")
+    private String GOOGLE_REDIRECT_URI;
+
+    public GoogleAccessTokenRes getAccessToken(String code) {
+        return WebClient.create(GOOGLE_ACCESS_TOKEN_URL).post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", GOOGLE_CLIENT_ID)
+                        .queryParam("client_secret", GOOGLE_SECRET_ID)
+                        .queryParam("redirect_uri", GOOGLE_REDIRECT_URI)
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //TODO: Custom Exception
+                .bodyToMono(GoogleAccessTokenRes.class)
+                .block();
+    }
+
+    public GoogleMemberInfoRes getUserInfo(String accessToken) {
+        return WebClient.create(GOOGLE_MEMBER_INFO_URL).get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/userinfo")
+                        .build(true))
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                //TODO: Custom Exception
+                .bodyToMono(GoogleMemberInfoRes.class)
+                .block();
+    }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/GoogleApiClient.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/GoogleApiClient.java
@@ -1,0 +1,4 @@
+package com.be.squeak_squeak.member.oauth.google;
+
+public class GoogleApiClient {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/GoogleJoinStrategy.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/GoogleJoinStrategy.java
@@ -1,0 +1,44 @@
+package com.be.squeak_squeak.member.oauth.google;
+
+import com.be.squeak_squeak.member.oauth.dto.JoinReq;
+import com.be.squeak_squeak.member.entity.Member;
+import com.be.squeak_squeak.member.entity.SocialType;
+import com.be.squeak_squeak.member.oauth.SocialJoinStrategy;
+import com.be.squeak_squeak.member.oauth.google.dto.GoogleAccessTokenRes;
+import com.be.squeak_squeak.member.oauth.google.dto.GoogleMemberInfoRes;
+import com.be.squeak_squeak.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class GoogleJoinStrategy implements SocialJoinStrategy {
+
+    private final GoogleApiClient googleApiClient;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Member join(JoinReq joinReq) {
+        memberRepository.findByPhoneNumber(joinReq.phoneNumber()).ifPresent(
+                member -> {
+                    throw new IllegalArgumentException("이미 가입된 회원입니다.");
+                }
+        );
+
+        GoogleAccessTokenRes accessTokenRes = googleApiClient.getAccessToken(joinReq.code());
+        GoogleMemberInfoRes response = googleApiClient.getUserInfo(accessTokenRes.accessToken());
+        return Member.builder()
+                .nickname(response.name()) // 구글 사용자 이름
+                .image("기본이미지") // 기본 이미지 설정
+                .email(response.email()) // 구글 이메일
+                .phoneNumber(joinReq.phoneNumber())
+                .socialType(SocialType.GOOGLE) // 소셜 타입을 구글로 설정
+                .socialUuid(response.id()) // 구글 사용자 ID
+                .build();
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.GOOGLE; // 소셜 타입을 구글로 반환
+    }
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/GoogleLoginStrategy.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/GoogleLoginStrategy.java
@@ -1,0 +1,33 @@
+package com.be.squeak_squeak.member.oauth.google;
+
+import com.be.squeak_squeak.member.oauth.dto.LoginReq;
+import com.be.squeak_squeak.member.entity.Member;
+import com.be.squeak_squeak.member.entity.SocialType;
+import com.be.squeak_squeak.member.oauth.SocialLoginStrategy;
+import com.be.squeak_squeak.member.oauth.google.dto.GoogleAccessTokenRes;
+import com.be.squeak_squeak.member.oauth.google.dto.GoogleMemberInfoRes;
+import com.be.squeak_squeak.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleLoginStrategy implements SocialLoginStrategy {
+
+    private final GoogleApiClient googleApiClient;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Member login(LoginReq loginReq) {
+        GoogleAccessTokenRes accessTokenRes = googleApiClient.getAccessToken(loginReq.code());
+        GoogleMemberInfoRes googleUserInfoRes = googleApiClient.getUserInfo(accessTokenRes.accessToken());
+        return memberRepository.findBySocialUuid(googleUserInfoRes.id()).orElseThrow(
+                () -> new IllegalArgumentException("회원가입이 필요합니다.")
+        );
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.GOOGLE; // 소셜 타입을 구글로 반환
+    }
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/dto/GoogleAccessTokenRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/dto/GoogleAccessTokenRes.java
@@ -1,0 +1,13 @@
+package com.be.squeak_squeak.member.oauth.google.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleAccessTokenRes (
+        @JsonProperty("access_token")
+        String accessToken,
+        @JsonProperty("expires_in")
+        Long expiresIn,
+        @JsonProperty("token_type")
+        String tokenType
+){
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/dto/GoogleMemberInfoRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/dto/GoogleMemberInfoRes.java
@@ -1,0 +1,8 @@
+package com.be.squeak_squeak.member.oauth.google.dto;
+
+public record GoogleMemberInfoRes (
+        String id,
+        String email,
+        String name
+){
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/dto/GoogleMemberInfoRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/dto/GoogleMemberInfoRes.java
@@ -3,8 +3,8 @@ package com.be.squeak_squeak.member.oauth.google.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record GoogleMemberInfoRes (
-        @JsonProperty("id") String id,
-        @JsonProperty("email") String email,
-        @JsonProperty("name") String name
+        @JsonProperty("sub") String id,
+        @JsonProperty("name") String name,
+        @JsonProperty("email") String email
 ){
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/dto/GoogleMemberInfoRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/member/oauth/google/dto/GoogleMemberInfoRes.java
@@ -1,8 +1,10 @@
 package com.be.squeak_squeak.member.oauth.google.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record GoogleMemberInfoRes (
-        String id,
-        String email,
-        String name
+        @JsonProperty("id") String id,
+        @JsonProperty("email") String email,
+        @JsonProperty("name") String name
 ){
 }

--- a/squeak-squeak/src/main/resources/application-local.yml
+++ b/squeak-squeak/src/main/resources/application-local.yml
@@ -36,3 +36,10 @@ naver:
   secret-id: ${NAVER_SECRET_ID}
   access-token-url: ${NAVER_ACCESS_TOKEN_URL}
   member-info-url: ${NAVER_MEMBER_INFO_URL}
+
+google:
+  client-id: ${GOOGLE_CLIENT_ID}
+  secret-id: ${GOOGLE_SECRET_ID}
+  access-token-url: ${GOOGLE_ACCESS_TOKEN_URL}
+  member-info-url: ${GOOGLE_MEMBER_INFO_URL}
+  redirect-uri: ${GOOGLE_REDIRECT_URI}


### PR DESCRIPTION
## ❗️ 관련 이슈 번호
- Close #13 

## 🚀 작업 내용
구글 소셜 로그인 기능을 구현했습니다.

## 🤔 고민했던 내용
### 문제1. google accesstoken을 요청하는 과정에서 bad request 에러가 계속 뜨는 문제가 발생

#### 해결 시도1.
구글링 해본 결과 code, redirect uri, client id, client secret 값이 잘못됐을 경우 bad request 에러가 발생한다는 걸 알게됨.
code, client id, client secret 값은 틀린 부분이 없어서, redirect uri 값만 변경해보면서 테스트를 진행함.
=> 해결 안됨.

#### 해결 시도2.
구글에서 인가코드를 요청하여 발급할 경우, 발급된 해당 코드 앞의 "%2F" 부분이 "/"로 인코딩 되지 않고 발급되어 구글에 해당 인가코드로 accessToken을 요청하게 되면 해당 인가코드를 잘못된 인가코드로 인식한다는 것을 발견함.

발급된 코드(디코딩 전)
```
4%2F0AanRRru6nEWKWc3BlUtkEWSdM3AQx1wNZ9-JrdhCdjhDUHLc18oCNEzDLaznzFaZwYDfJg
```

발급된 코드(디코딩 후)
```
4/0AanRRru6nEWKWc3BlUtkEWSdM3AQx1wNZ9-JrdhCdjhDUHLc18oCNEzDLaznzFaZwYDfJg
```

https://meyerweb.com/eric/tools/dencoder/
위 사이트에서 인가코드를 decode 시킨 후 accesstoken을 발급하니 정상적으로 발급됨.

=> 해결.

</br>

### 문제2. 사용자 정보가 제대로 응답되지 않음.
#### 해결 시도
본 프로젝트에서 구글에서 받아와야 하는 사용자의 정보는 id, name, email임.
사용자 정보를 요청을 했을 경우 구글에서는

```
{
"sub": "***",
"name": "***",
"given_name": "**",
"family_name": "*",
"picture": "*****",
"email": "***",
"email_verified": true
}
```

으로 응답이 오게됨.

즉, WebClient로 요청한 후 응답 데이터를 GoogleMemberInfoRes 객체로 매핑할 때, 모든 필드가 매핑되지 않는 문제가 발생함.
때문에 JSON 키와 DTO의 필드 이름을 @JsonProperty 어노테이션을 써서 매핑을 맞춰줌.

_참고로 Google API의 응답 JSON에서는 id 필드가 아니라 sub라는 필드를 사용하고 있음_

=> 해결.


</br>

## 💬 리뷰 중점사항
