### PR TITLE
feat : 그룹 생성 기능

### DIFF
--- a/squeak-squeak/.idea/vcs.xml
+++ b/squeak-squeak/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
@@ -1,0 +1,9 @@
+package com.be.squeak_squeak.group.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserGroupController {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
@@ -1,9 +1,24 @@
 package com.be.squeak_squeak.group.controller;
 
+import com.be.squeak_squeak.common.config.ApiResponse;
+import com.be.squeak_squeak.common.config.ApiResponseGenerator;
+import com.be.squeak_squeak.group.dto.CreateGroupReq;
+import com.be.squeak_squeak.group.dto.CreateGroupRes;
+import com.be.squeak_squeak.group.service.UserGroupService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/groups")
 public class UserGroupController {
+    private final UserGroupService userGroupService;
+
+    @PostMapping("/create")
+    public ApiResponse<ApiResponse.CustomBody<CreateGroupRes>> createGroup(@RequestBody CreateGroupReq request,
+                                                                           @RequestParam Long memberId) {
+        CreateGroupRes createGroupRes = userGroupService.createGroup(request, memberId);
+        return ApiResponseGenerator.success(createGroupRes, HttpStatus.OK);
+    }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/CreateGroupReq.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/CreateGroupReq.java
@@ -1,0 +1,8 @@
+package com.be.squeak_squeak.group.dto;
+
+public record CreateGroupReq(
+        String name,
+        String image,
+        String description
+) {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/CreateGroupRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/CreateGroupRes.java
@@ -1,0 +1,13 @@
+package com.be.squeak_squeak.group.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CreateGroupRes(
+        Long id,
+        String name,
+        String image,
+        String description,
+        String inviteCode
+) {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
@@ -2,12 +2,16 @@ package com.be.squeak_squeak.group.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "user_group")
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
+@Getter
 public class UserGroup {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/repository/UserGroupRepository.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/repository/UserGroupRepository.java
@@ -1,0 +1,7 @@
+package com.be.squeak_squeak.group.repository;
+
+import com.be.squeak_squeak.group.entity.UserGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -1,0 +1,9 @@
+package com.be.squeak_squeak.group.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserGroupService {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -1,9 +1,60 @@
 package com.be.squeak_squeak.group.service;
 
+import com.be.squeak_squeak.group.dto.CreateGroupReq;
+import com.be.squeak_squeak.group.dto.CreateGroupRes;
+import com.be.squeak_squeak.group.entity.UserGroup;
+import com.be.squeak_squeak.group.repository.UserGroupRepository;
+import com.be.squeak_squeak.groupMember.entity.GroupMember;
+import com.be.squeak_squeak.groupMember.entity.MemberStatus;
+import com.be.squeak_squeak.groupMember.repository.GroupMemberRepository;
+import com.be.squeak_squeak.member.entity.Member;
+import com.be.squeak_squeak.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserGroupService {
+    private final UserGroupRepository userGroupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final MemberRepository memberRepository;
+
+    public CreateGroupRes createGroup(CreateGroupReq request, Long memberId) {
+        // 초대 코드 생성
+        // String inviteCode = generateInviteCode();
+
+        Member creator = memberRepository.findById(memberId)
+                            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        UserGroup group = UserGroup.builder()
+                .name(request.name())
+                .image(request.image())
+                .description(request.description())
+                .totalMemberCount(1) // 그룹 생성 시 1명 (그룹장)
+                .inviteCode("임시 초대 코드")
+                .build();
+
+        // 그룹 저장
+        userGroupRepository.save(group);
+
+        GroupMember groupMember = GroupMember.builder()
+                .userGroup(group)
+                .status(MemberStatus.OWNER)
+                .member(creator)
+                .build();
+
+        groupMemberRepository.save(groupMember);
+
+        return CreateGroupRes.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .image(group.getImage())
+                .description(group.getDescription())
+                .inviteCode(group.getInviteCode())
+                .build();
+    }
+
+    private String generateInviteCode() {
+        return null;
+    }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -1,5 +1,6 @@
 package com.be.squeak_squeak.group.service;
 
+import ch.qos.logback.core.testUtil.RandomUtil;
 import com.be.squeak_squeak.group.dto.CreateGroupReq;
 import com.be.squeak_squeak.group.dto.CreateGroupRes;
 import com.be.squeak_squeak.group.entity.UserGroup;
@@ -12,6 +13,8 @@ import com.be.squeak_squeak.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
+
 @Service
 @RequiredArgsConstructor
 public class UserGroupService {
@@ -21,7 +24,8 @@ public class UserGroupService {
 
     public CreateGroupRes createGroup(CreateGroupReq request, Long memberId) {
         // 초대 코드 생성
-        // String inviteCode = generateInviteCode();
+         String inviteCode = generateInviteCode();
+
 
         Member creator = memberRepository.findById(memberId)
                             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
@@ -31,7 +35,7 @@ public class UserGroupService {
                 .image(request.image())
                 .description(request.description())
                 .totalMemberCount(1) // 그룹 생성 시 1명 (그룹장)
-                .inviteCode("임시 초대 코드")
+                .inviteCode(inviteCode)
                 .build();
 
         // 그룹 저장
@@ -55,6 +59,15 @@ public class UserGroupService {
     }
 
     private String generateInviteCode() {
-        return null;
+        SecureRandom random = new SecureRandom();
+        StringBuilder inviteCode = new StringBuilder();
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        for (int i = 0; i < 8; i++) { // 초대 코드는 8자리
+            int index = random.nextInt(characters.length());
+            inviteCode.append(characters.charAt(index));
+        }
+
+        return inviteCode.toString();
     }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/entity/GroupMember.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/entity/GroupMember.java
@@ -4,12 +4,14 @@ import com.be.squeak_squeak.group.entity.UserGroup;
 import com.be.squeak_squeak.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "group_member")
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class GroupMember {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/repository/GroupMemberRepository.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/repository/GroupMemberRepository.java
@@ -1,0 +1,7 @@
+package com.be.squeak_squeak.groupMember.repository;
+
+import com.be.squeak_squeak.groupMember.entity.GroupMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+}


### PR DESCRIPTION
## ❗️ 관련 이슈 번호
- Close #22 

## 🚀 작업 내용
- 사용자가 그룹을 생성하는 기능을 구현했습니다.
- 일단, 생성할 그룹정보를 담은 CreateGroupReq와 그룹을 생성하는 멤버의 id를 요청 값에 넣도록 했습니다.
  - 이부분은 추후에 인증, 인가 기능 적용하면서 수정 될 것 같습니다.
- 그룹을 생성하면 랜덤한 8자리 초대 코드가 생성되게 하였습니다.

## 🤔 고민했던 내용
- 커스텀 예외 처리부분이 빨리 구현되어야 할 것 같습니다...!!!

## 💬 리뷰 중점사항

