### PR TITLE
feat : 그룹 수정 기능

### DIFF
--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
@@ -4,6 +4,8 @@ import com.be.squeak_squeak.common.config.ApiResponse;
 import com.be.squeak_squeak.common.config.ApiResponseGenerator;
 import com.be.squeak_squeak.group.dto.CreateGroupReq;
 import com.be.squeak_squeak.group.dto.CreateGroupRes;
+import com.be.squeak_squeak.group.dto.UpdateGroupReq;
+import com.be.squeak_squeak.group.dto.UpdateGroupRes;
 import com.be.squeak_squeak.group.service.UserGroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,5 +22,21 @@ public class UserGroupController {
                                                                            @RequestParam Long memberId) {
         CreateGroupRes createGroupRes = userGroupService.createGroup(request, memberId);
         return ApiResponseGenerator.success(createGroupRes, HttpStatus.OK);
+    }
+
+    @GetMapping("/update/{groupId}")
+    public ApiResponse<ApiResponse.CustomBody<UpdateGroupRes>> getUserGroup(@PathVariable Long groupId,
+                                                                            @RequestBody UpdateGroupReq request,
+                                                                            @RequestParam Long memberId){
+        UpdateGroupRes response = userGroupService.getUserGroup(groupId, request, memberId);
+        return ApiResponseGenerator.success(response, HttpStatus.OK);
+    }
+
+    @PutMapping("/update/{groupId}")
+    public ApiResponse<ApiResponse.CustomBody<UpdateGroupRes>> updateGroup(@PathVariable Long groupId,
+                                                                           @RequestBody UpdateGroupReq request,
+                                                                           @RequestParam Long memberId){
+        UpdateGroupRes response = userGroupService.updateGroup(groupId, request, memberId);
+        return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
@@ -26,9 +26,8 @@ public class UserGroupController {
 
     @GetMapping("/update/{groupId}")
     public ApiResponse<ApiResponse.CustomBody<UpdateGroupRes>> getUserGroup(@PathVariable Long groupId,
-                                                                            @RequestBody UpdateGroupReq request,
                                                                             @RequestParam Long memberId){
-        UpdateGroupRes response = userGroupService.getUserGroup(groupId, request, memberId);
+        UpdateGroupRes response = userGroupService.getUserGroup(groupId, memberId);
         return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
 

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/UpdateGroupReq.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/UpdateGroupReq.java
@@ -1,0 +1,8 @@
+package com.be.squeak_squeak.group.dto;
+
+public record UpdateGroupReq(
+        String name,
+        String image,
+        String description
+) {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/UpdateGroupRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/UpdateGroupRes.java
@@ -1,0 +1,12 @@
+package com.be.squeak_squeak.group.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateGroupRes(
+        Long id,
+        String name,
+        String image,
+        String description
+) {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
@@ -27,16 +27,9 @@ public class UserGroup {
 
     private String inviteCode;
 
-    public void setName(String name){
+    public void updateGroup(String name, String image, String description){
         this.name = name;
-    }
-
-    public void setImage(String image){
         this.image = image;
-    }
-
-    public void setDescription(String description){
         this.description = description;
     }
-
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
@@ -26,4 +26,17 @@ public class UserGroup {
     private int totalMemberCount;
 
     private String inviteCode;
+
+    public void setName(String name){
+        this.name = name;
+    }
+
+    public void setImage(String image){
+        this.image = image;
+    }
+
+    public void setDescription(String description){
+        this.description = description;
+    }
+
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -82,6 +82,9 @@ public class UserGroupService {
     }
 
     public void checkOwnerPermission(UserGroup group, Member member) {
-
+        boolean isOwner = groupMemberRepository.findByUserGroupAndMemberAndStatus(group, member, MemberStatus.OWNER).isPresent();
+        if (!isOwner) {
+            throw new IllegalStateException("이 작업은 OWNER만 수행할 수 있습니다.");
+        }
     }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -73,12 +73,46 @@ public class UserGroupService {
         return inviteCode.toString();
     }
 
-    public UpdateGroupRes getUserGroup(Long groupId, UpdateGroupReq request, Long memberId) {
-        return null;
+    public UpdateGroupRes getUserGroup(Long groupId, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        UserGroup group = userGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        // OWNER 권한 확인
+        checkOwnerPermission(group, member);
+
+        return UpdateGroupRes.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .image(group.getImage())
+                .description(group.getDescription())
+                .build();
     }
 
     public UpdateGroupRes updateGroup(Long groupId, UpdateGroupReq request, Long memberId) {
-        return null;
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        UserGroup group = userGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        // OWNER 권한 확인
+        checkOwnerPermission(group, member);
+
+        group.setName(request.name());
+        group.setImage(request.image());
+        group.setDescription(request.description());
+
+        userGroupRepository.save(group);
+
+        return UpdateGroupRes.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .image(group.getImage())
+                .description(group.getDescription())
+                .build();
     }
 
     public void checkOwnerPermission(UserGroup group, Member member) {

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -1,6 +1,5 @@
 package com.be.squeak_squeak.group.service;
 
-import ch.qos.logback.core.testUtil.RandomUtil;
 import com.be.squeak_squeak.group.dto.CreateGroupReq;
 import com.be.squeak_squeak.group.dto.CreateGroupRes;
 import com.be.squeak_squeak.group.dto.UpdateGroupReq;
@@ -14,6 +13,7 @@ import com.be.squeak_squeak.member.entity.Member;
 import com.be.squeak_squeak.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 
@@ -73,6 +73,7 @@ public class UserGroupService {
         return inviteCode.toString();
     }
 
+    @Transactional
     public UpdateGroupRes getUserGroup(Long groupId, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
@@ -101,11 +102,7 @@ public class UserGroupService {
         // OWNER 권한 확인
         checkOwnerPermission(group, member);
 
-        group.setName(request.name());
-        group.setImage(request.image());
-        group.setDescription(request.description());
-
-        userGroupRepository.save(group);
+        group.updateGroup(request.name(), request.image(), request.description());
 
         return UpdateGroupRes.builder()
                 .id(group.getId())

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -3,6 +3,8 @@ package com.be.squeak_squeak.group.service;
 import ch.qos.logback.core.testUtil.RandomUtil;
 import com.be.squeak_squeak.group.dto.CreateGroupReq;
 import com.be.squeak_squeak.group.dto.CreateGroupRes;
+import com.be.squeak_squeak.group.dto.UpdateGroupReq;
+import com.be.squeak_squeak.group.dto.UpdateGroupRes;
 import com.be.squeak_squeak.group.entity.UserGroup;
 import com.be.squeak_squeak.group.repository.UserGroupRepository;
 import com.be.squeak_squeak.groupMember.entity.GroupMember;
@@ -69,5 +71,17 @@ public class UserGroupService {
         }
 
         return inviteCode.toString();
+    }
+
+    public UpdateGroupRes getUserGroup(Long groupId, UpdateGroupReq request, Long memberId) {
+        return null;
+    }
+
+    public UpdateGroupRes updateGroup(Long groupId, UpdateGroupReq request, Long memberId) {
+        return null;
+    }
+
+    public void checkOwnerPermission(UserGroup group, Member member) {
+
     }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/repository/GroupMemberRepository.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/repository/GroupMemberRepository.java
@@ -1,7 +1,13 @@
 package com.be.squeak_squeak.groupMember.repository;
 
+import com.be.squeak_squeak.group.entity.UserGroup;
 import com.be.squeak_squeak.groupMember.entity.GroupMember;
+import com.be.squeak_squeak.groupMember.entity.MemberStatus;
+import com.be.squeak_squeak.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+    Optional<GroupMember> findByUserGroupAndMemberAndStatus(UserGroup userGroup, Member member, MemberStatus status);
 }


### PR DESCRIPTION
## ❗️ 관련 이슈 번호
- Close #25 

## 🚀 작업 내용
- "OWENR 권한을 가지고 있는 사용자"가 그룹을 조회하는 기능
- "OWENR 권한을 가지고 있는 사용자"가 그룹을 수정하는 기능

## 🤔 고민했던 내용
- 수정을 할때 set 메서드를 사용해야 될지, 아니면 builder 패턴을 적용해야할지 고민했습니다. 결론적으로는 속성이 적고, 객체의 상태를 자주 변경할 필요가 없는 그룹 수정의 경우에는 set 메서드를 사용하는 것이 효율적일 것 같아서 set 메서드를 사용해서 수정 기능을 구현했습니다. 혹시 다른 좋은 의견 있으면 코멘트 작성해주세요!!
- @AuthMember 를 적용하려고 했는데 MemberInfo로 받아오는 값을 수정해야 할 것같아 적용하지 않았습니다. 추후에 리팩토링하면서 적용시키도록 하겠습니다.
- 그룹 수정을 위해서는 그룹의 기존 정보를 가져와야 했기 때문에, 수정을 위한 그룹 정보를 가져오는 조회 메서드를 구현하였습니다. 이때 사용한 메서드명들이 추후 그룹을 조회하는 기능을 따로 만들때 겹치지않을까라는 고민을 해봤습니다. 지금은 일단 getUserGroup()로 구현 해놨습니다.

## 💬 리뷰 중점사항
