### PR TITLE
feat : 그룹 가입 요청 대기 목록 조회

### DIFF
--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/controller/GroupMemberController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/controller/GroupMemberController.java
@@ -1,0 +1,30 @@
+package com.be.squeak_squeak.groupMember.controller;
+
+import com.be.squeak_squeak.common.auth.AuthMember;
+import com.be.squeak_squeak.common.auth.MemberInfo;
+import com.be.squeak_squeak.common.config.ApiResponse;
+import com.be.squeak_squeak.common.config.ApiResponseGenerator;
+import com.be.squeak_squeak.groupMember.dto.RequestListRes;
+import com.be.squeak_squeak.groupMember.service.GroupMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/group-member")
+public class GroupMemberController {
+    private final GroupMemberService groupMemberService;
+
+    @GetMapping("/{groupId}/join-requests")
+    public ApiResponse<ApiResponse.CustomBody<List<RequestListRes>>> getRequestList(@PathVariable Long groupId,
+                                                                                    @AuthMember MemberInfo memberInfo){
+        List<RequestListRes> requestList = groupMemberService.getRequestList(groupId, memberInfo);
+        return ApiResponseGenerator.success(requestList, HttpStatus.OK);
+    }
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/dto/RequestListRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/dto/RequestListRes.java
@@ -1,0 +1,8 @@
+package com.be.squeak_squeak.groupMember.dto;
+
+public record RequestListRes(
+        Long memberId,
+        String memberNickname,
+        String groupName
+) {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/entity/GroupMember.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/entity/GroupMember.java
@@ -5,6 +5,7 @@ import com.be.squeak_squeak.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Getter
 public class GroupMember {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/repository/GroupMemberRepository.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/repository/GroupMemberRepository.java
@@ -6,8 +6,11 @@ import com.be.squeak_squeak.groupMember.entity.MemberStatus;
 import com.be.squeak_squeak.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
     Optional<GroupMember> findByUserGroupAndMemberAndStatus(UserGroup userGroup, Member member, MemberStatus status);
+
+    List<GroupMember> findByUserGroupAndStatus(UserGroup group, MemberStatus memberStatus);
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/service/GroupMemberService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/service/GroupMemberService.java
@@ -1,7 +1,14 @@
 package com.be.squeak_squeak.groupMember.service;
 
 import com.be.squeak_squeak.common.auth.MemberInfo;
+import com.be.squeak_squeak.group.entity.UserGroup;
+import com.be.squeak_squeak.group.repository.UserGroupRepository;
 import com.be.squeak_squeak.groupMember.dto.RequestListRes;
+import com.be.squeak_squeak.groupMember.entity.GroupMember;
+import com.be.squeak_squeak.groupMember.entity.MemberStatus;
+import com.be.squeak_squeak.groupMember.repository.GroupMemberRepository;
+import com.be.squeak_squeak.member.entity.Member;
+import com.be.squeak_squeak.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,8 +18,27 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class GroupMemberService {
+    private final UserGroupRepository userGroupRepository;
+    private final MemberRepository memberRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
     @Transactional(readOnly = true)
     public List<RequestListRes> getRequestList(Long groupId, MemberInfo memberInfo) {
-        return null;
+        Member member = memberRepository.findById(memberInfo.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        UserGroup group = userGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        // 특정 그룹에서 OWNER인지 확인
+        groupMemberRepository.findByUserGroupAndMemberAndStatus(group, member, MemberStatus.OWNER)
+                .orElseThrow(() -> new IllegalArgumentException("회원은 그룹의 OWNER가 아닙니다."));
+
+        // "waiting" 상태인 멤버 조회
+        List<GroupMember> waitingMembers = groupMemberRepository.findByUserGroupAndStatus(group, MemberStatus.WAITING);
+
+        return waitingMembers.stream()
+                .map(g -> new RequestListRes(g.getMember().getId(), g.getMember().getNickname(), group.getName()))
+                .toList();
     }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/service/GroupMemberService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/service/GroupMemberService.java
@@ -1,0 +1,18 @@
+package com.be.squeak_squeak.groupMember.service;
+
+import com.be.squeak_squeak.common.auth.MemberInfo;
+import com.be.squeak_squeak.groupMember.dto.RequestListRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupMemberService {
+    @Transactional(readOnly = true)
+    public List<RequestListRes> getRequestList(Long groupId, MemberInfo memberInfo) {
+        return null;
+    }
+}


### PR DESCRIPTION
## ❗️ 관련 이슈 번호
- Close #27 

## 🚀 작업 내용
- 그룹의 OWNER권한 사용자만 그룹 가입 요청 목록을 조회할 수 있는 기능을 구현했습니다.
- 로직 흐름:
  1. groupId와 memberInfo를 받아서 해당 그룹을 찾음
  2. 요청자가 해당 그룹의 OWNER인지 확인
  3. OWNER라면, WAITING 상태의 멤버 리스트를 조회
  4. 조회된 멤버 정보를 RequestListRes(dto)로 변환하여 반환

## 🤔 고민했던 내용
- @Builder 대신 new 키워드 사용으로 record DTO 생성을 개선
  - record는 불변한 DTO이며, 모든 필드를 받는 생성자를 자동으로 제공하기 때문에 @Builder가 불필요합니다. 
  - 따라서, 별도로 빌더를 만들지 않고 new RequestListRes(...) 방식으로 생성하면 됩니다. 
  - 또한, record의 필드는 final로 선언되어 값이 변경될 일이 없으므로, 빌더 패턴을 사용할 필요가 없습니다.

## 💬 리뷰 중점사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->
