### PR TITLE
feat : 그룹 구성원 리스트 조회

### DIFF
--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
@@ -7,6 +7,8 @@ import com.be.squeak_squeak.common.config.ApiResponse.CustomBody;
 import com.be.squeak_squeak.common.config.ApiResponseGenerator;
 import com.be.squeak_squeak.group.dto.CreateGroupReq;
 import com.be.squeak_squeak.group.dto.CreateGroupRes;
+import com.be.squeak_squeak.group.dto.GetGoupMemberListRes;
+import com.be.squeak_squeak.group.dto.GetGroupMemberRes;
 import com.be.squeak_squeak.group.dto.JoinGroupReq;
 import com.be.squeak_squeak.group.dto.SearchGroupRes;
 import com.be.squeak_squeak.group.dto.UpdateGroupReq;
@@ -22,6 +24,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/groups")
 public class UserGroupController {
     private final UserGroupService userGroupService;
+
+    @GetMapping("/{groupId}")
+    public ApiResponse<ApiResponse.CustomBody<GetGoupMemberListRes>> getGroupUsers(@PathVariable Long groupId,
+                                                                                   @AuthMember MemberInfo memberInfo) {
+        GetGoupMemberListRes response = userGroupService.getGroupUsers(groupId, memberInfo);
+        return ApiResponseGenerator.success(response, HttpStatus.OK);
+    }
 
     @PostMapping("/create")
     public ApiResponse<ApiResponse.CustomBody<CreateGroupRes>> createGroup(@RequestBody CreateGroupReq request,

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -3,6 +3,8 @@ package com.be.squeak_squeak.group.service;
 import com.be.squeak_squeak.common.auth.MemberInfo;
 import com.be.squeak_squeak.group.dto.CreateGroupReq;
 import com.be.squeak_squeak.group.dto.CreateGroupRes;
+import com.be.squeak_squeak.group.dto.GetGoupMemberListRes;
+import com.be.squeak_squeak.group.dto.GetGroupMemberRes;
 import com.be.squeak_squeak.group.dto.JoinGroupReq;
 import com.be.squeak_squeak.group.dto.SearchGroupRes;
 import com.be.squeak_squeak.group.dto.UpdateGroupReq;
@@ -28,6 +30,36 @@ public class UserGroupService {
     private final GroupMemberRepository groupMemberRepository;
     private final MemberRepository memberRepository;
     private final UserGroupCustomRepository userGroupCustomRepository;
+
+    @Transactional(readOnly = true)
+    public GetGoupMemberListRes getGroupUsers(Long groupId, MemberInfo memberInfo) {
+        Member member = memberRepository.findById(memberInfo.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        UserGroup group = userGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        // 그룹 멤버 조회 (OWNER, MEMBER)
+        List<GetGroupMemberRes> memberResList = groupMemberRepository.findGroupUsersByGroupIdAndStatus(group.getId(),
+                List.of(MemberStatus.OWNER, MemberStatus.MEMBER));
+        // 가입한 사용자 정보 조회
+        GroupMember groupMember = groupMemberRepository.findByUserGroupAndMember(group, member)
+                .orElseThrow(() -> new IllegalArgumentException("그룹에 가입되어 있지 않습니다."));
+        // 로그인한 사용자의 권한 조회
+        MemberStatus logedInMemberStatus = groupMember.getStatus();
+        if(logedInMemberStatus == MemberStatus.WAITING) {
+            throw new IllegalStateException("가입 승인 대기중인 사용자입니다.");
+        }
+        // 대기중인 사용자 수 조회
+        List<GroupMember> waitingMembers = groupMemberRepository.findByUserGroupAndStatus(group, MemberStatus.WAITING);
+        int waitingCount = waitingMembers.size();
+
+        return new GetGoupMemberListRes(
+                logedInMemberStatus == MemberStatus.OWNER,
+                waitingCount,
+                memberResList
+        );
+    }
 
     @Transactional
     public CreateGroupRes createGroup(CreateGroupReq request, Long memberId) {

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/repository/GroupMemberRepository.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/groupMember/repository/GroupMemberRepository.java
@@ -1,5 +1,6 @@
 package com.be.squeak_squeak.groupMember.repository;
 
+import com.be.squeak_squeak.group.dto.GetGroupMemberRes;
 import com.be.squeak_squeak.group.entity.UserGroup;
 import com.be.squeak_squeak.groupMember.entity.GroupMember;
 import com.be.squeak_squeak.groupMember.entity.MemberStatus;
@@ -8,9 +9,21 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
     Optional<GroupMember> findByUserGroupAndMemberAndStatus(UserGroup userGroup, Member member, MemberStatus status);
 
     List<GroupMember> findByUserGroupAndStatus(UserGroup group, MemberStatus memberStatus);
+
+    @Query("SELECT new com.be.squeak_squeak.group.dto.GetGroupMemberRes(gm.member.id, gm.member.nickname, gm.member.image) "
+            +
+            "FROM GroupMember gm " +
+            "WHERE gm.userGroup.id = :groupId " +
+            "AND gm.status IN (:statuses)")
+    List<GetGroupMemberRes> findGroupUsersByGroupIdAndStatus(@Param("groupId") Long groupId,
+                                                             @Param("statuses") List<MemberStatus> statuses);
+
+    Optional<GroupMember> findByUserGroupAndMember(UserGroup userGroup, Member member);
 }

--- a/squeak-squeak/src/main/resources/application-local.yml
+++ b/squeak-squeak/src/main/resources/application-local.yml
@@ -1,5 +1,10 @@
 spring:
+  sql:
+    init:
+      data-locations: classpath:init.sql
+      mode: always
   jpa:
+    defer-datasource-initialization: true
     show-sql: true
     hibernate:
       ddl-auto: create-drop

--- a/squeak-squeak/src/main/resources/init.sql
+++ b/squeak-squeak/src/main/resources/init.sql
@@ -1,0 +1,43 @@
+INSERT INTO member (nickname, image, email, phone_number, social_type, social_uuid, total_group, total_vote)
+VALUES ('john_doe', null, 'john.doe@example.com', '010-1234-5678', 'GOOGLE', 'uuid-1234', 1, 0);
+
+INSERT INTO member (nickname, image, email, phone_number, social_type, social_uuid, total_group, total_vote)
+VALUES ('alice_wonder', null, 'alice.wonder@example.com', '010-9876-5432', 'KAKAO', 'uuid-5678', 1, 0);
+
+INSERT INTO member (nickname, image, email, phone_number, social_type, social_uuid, total_group, total_vote)
+VALUES ('bob_builder', null, 'bob.builder@example.com', '010-4567-7890', 'NAVER', 'uuid-9012', 1, 0);
+
+INSERT INTO member (nickname, image, email, phone_number, social_type, social_uuid, total_group, total_vote)
+VALUES ('charlie_brown', null, 'charlie.brown@example.com', '010-1111-2222', 'NAVER', 'uuid-3456', 1, 0);
+
+INSERT INTO member (nickname, image, email, phone_number, social_type, social_uuid, total_group, total_vote)
+VALUES ('diana_prince', null, 'diana.prince@example.com', '010-3333-4444', 'KAKAO', 'uuid-7890', 0, 0);
+
+
+INSERT INTO user_group (name, image, description, total_member_count, invite_code)
+VALUES ('Developers Hub', null, 'A community for software developers.', 1, 'INV123');
+
+INSERT INTO user_group (name, image, description, total_member_count, invite_code)
+VALUES ('Fitness Enthusiasts', null, 'A group dedicated to fitness and health.', 3, 'FIT456');
+
+INSERT INTO group_member (status, member_id, user_group_id)
+VALUES ('OWNER', 1, 1);
+
+INSERT INTO group_member (status, member_id, user_group_id)
+VALUES ('WAITING', 4, 1);
+
+INSERT INTO group_member (status, member_id, user_group_id)
+VALUES ('WAITING', 1, 2);
+
+INSERT INTO group_member (status, member_id, user_group_id)
+VALUES ('OWNER', 2, 2);
+
+INSERT INTO group_member (status, member_id, user_group_id)
+VALUES ('MEMBER', 3, 2);
+
+INSERT INTO group_member (status, member_id, user_group_id)
+VALUES ('WAITING', 4, 2);
+
+
+
+


### PR DESCRIPTION
## ❗️ 관련 이슈 번호
- Close #30 

## 🚀 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능) -->
그룹 아이디에 해당하는 그룹 구성원을 조회하는 기능을 작성하였습니다.

1. 로그인 한 회원이 존재하는 회원인지 확인
2. 그룹 아이디가 존재하는 그룹인지 확인
3. OWNER, MEMBER 권한을 갖고 있는 GroupMember 리스트 가져오기
4. 로그인 한 사용자의 OWNER 여부 확인 (FE를 위해)
5. 대기중인 사용자 수 조회 (FE를 위해)

## 🤔 고민했던 내용
하나의 api를 호출하는데에 5번의 SELECT 쿼리가 호출됩니다.
매우 비효율적인 것 같은데 줄일 수 있는 방법이 있을 지 고민했습니다.
줄일 수 있다면 어떻게 줄일 수 있을까요?? 😭

## 💬 리뷰 중점사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->
이 코드는 절차지향적으로 구현되어있는 상황이라 나중에 리팩토링이 필요할 것 같습니다.!