### PR TITLE
feat: 그룹에 대한 이미지 저장 및 조회 기능

### DIFF
--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
@@ -36,32 +36,35 @@ public class UserGroupController {
         GetGoupMemberListRes response = userGroupService.getGroupUsers(groupId, memberInfo);
         return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
-
+    
     @PostMapping("/create")
-    public ApiResponse<ApiResponse.CustomBody<CreateGroupRes>> createGroup(@RequestBody CreateGroupReq request,
-                                                                           @RequestParam Long memberId) {
-        CreateGroupRes createGroupRes = userGroupService.createGroup(request, memberId);
+    public ApiResponse<ApiResponse.CustomBody<CreateGroupRes>> createGroup(@AuthMember MemberInfo memberInfo,
+                                                                            @RequestBody CreateGroupReq request) {
+        CreateGroupRes createGroupRes = userGroupService.createGroup(memberInfo, request);
         return ApiResponseGenerator.success(createGroupRes, HttpStatus.OK);
     }
 
-    @GetMapping("/update/{groupId}")
-    public ApiResponse<ApiResponse.CustomBody<UpdateGroupRes>> getUserGroup(@PathVariable Long groupId,
-                                                                            @RequestParam Long memberId) {
-        UpdateGroupRes response = userGroupService.getUserGroup(groupId, memberId);
+    // 그룹 이미지 생성
+    @PostMapping(value ="/create/{groupId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ApiResponse.CustomBody<Void>> createImageGroup(@AuthMember MemberInfo memberInfo,
+                                                                      @PathVariable Long groupId,
+                                                                      @RequestParam MultipartFile file) {
+        userGroupService.saveGroupImage(memberInfo, groupId, file);
+        return ApiResponseGenerator.success(null, HttpStatus.OK);
+    }
+
+    // 그룹 조회
+    @GetMapping("/read/{groupId}")
+    public ApiResponse<ApiResponse.CustomBody<UpdateGroupRes>> getUserGroup(@AuthMember MemberInfo memberInfo,
+                                                                            @PathVariable Long groupId) {
+        UpdateGroupRes response = userGroupService.getUserGroup(memberInfo, groupId);
         return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
 
-    @PutMapping("/update/{groupId}")
-    public ApiResponse<ApiResponse.CustomBody<UpdateGroupRes>> updateGroup(@PathVariable Long groupId,
-                                                                           @RequestBody UpdateGroupReq request,
-                                                                           @RequestParam Long memberId) {
-        UpdateGroupRes response = userGroupService.updateGroup(groupId, request, memberId);
-        return ApiResponseGenerator.success(response, HttpStatus.OK);
-    }
-
-    @GetMapping(value = "/{groupId}/image", produces = MediaType.IMAGE_JPEG_VALUE)
+    // 그룹 이미지 조회
+    @GetMapping(value = "/read/{groupId}/image", produces = MediaType.IMAGE_JPEG_VALUE)
     public ResponseEntity<Resource> getGroupImage(@AuthMember MemberInfo memberInfo,
-                                                       @PathVariable Long groupId) {
+                                                  @PathVariable Long groupId) {
 
         Resource imageResource = userGroupService.getGroupImage(memberInfo, groupId);
 
@@ -69,13 +72,23 @@ public class UserGroupController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + imageResource.getFilename() + "\"")
                 .body(imageResource);
     }
-    @PostMapping(value = "/{groupId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<ApiResponse.CustomBody<Void>> saveGroupImage(@AuthMember MemberInfo memberInfo,
-                                                                    @PathVariable Long groupId,
-                                                                    @RequestParam MultipartFile file) {
 
+    // 그룹 수정
+    @PutMapping("/update/{groupId}")
+    public ApiResponse<ApiResponse.CustomBody<UpdateGroupRes>> updateGroup(@AuthMember MemberInfo memberInfo,
+                                                                            @PathVariable Long groupId,
+                                                                           @RequestBody UpdateGroupReq request) {
+        UpdateGroupRes response = userGroupService.updateGroup(memberInfo, groupId, request);
+        return ApiResponseGenerator.success(response, HttpStatus.OK);
+    }
+
+    // 그룹 이미지 수정
+    @PutMapping(value = "/update/{groupId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ApiResponse.CustomBody<Void>> updateImageGroup(@AuthMember MemberInfo memberInfo,
+                                                                           @PathVariable Long groupId,
+                                                                           @RequestParam MultipartFile file) {
         userGroupService.saveGroupImage(memberInfo, groupId, file);
-        return ApiResponseGenerator.success(HttpStatus.OK);
+        return ApiResponseGenerator.success(null, HttpStatus.OK);
     }
 
     @GetMapping("/search")

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
@@ -16,8 +16,12 @@ import com.be.squeak_squeak.group.dto.UpdateGroupRes;
 import com.be.squeak_squeak.group.service.UserGroupService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,6 +56,18 @@ public class UserGroupController {
                                                                            @RequestParam Long memberId) {
         UpdateGroupRes response = userGroupService.updateGroup(groupId, request, memberId);
         return ApiResponseGenerator.success(response, HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/update/{groupId}/image", produces = MediaType.IMAGE_JPEG_VALUE)
+    public ResponseEntity<Resource> getGroupImage(@AuthMember MemberInfo memberInfo,
+                                                       @PathVariable Long groupId) {
+        return null;
+    }
+    @PostMapping(value = "/update/{groupId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ApiResponse.CustomBody<Void>> saveGroupImage(@RequestParam MultipartFile file,
+                                                                    @AuthMember MemberInfo memberInfo,
+                                                                    @PathVariable Long groupId) {
+        return null;
     }
 
     @GetMapping("/search")

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/controller/UserGroupController.java
@@ -17,6 +17,7 @@ import com.be.squeak_squeak.group.service.UserGroupService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -58,16 +59,23 @@ public class UserGroupController {
         return ApiResponseGenerator.success(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/update/{groupId}/image", produces = MediaType.IMAGE_JPEG_VALUE)
+    @GetMapping(value = "/{groupId}/image", produces = MediaType.IMAGE_JPEG_VALUE)
     public ResponseEntity<Resource> getGroupImage(@AuthMember MemberInfo memberInfo,
                                                        @PathVariable Long groupId) {
-        return null;
+
+        Resource imageResource = userGroupService.getGroupImage(memberInfo, groupId);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + imageResource.getFilename() + "\"")
+                .body(imageResource);
     }
-    @PostMapping(value = "/update/{groupId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<ApiResponse.CustomBody<Void>> saveGroupImage(@RequestParam MultipartFile file,
-                                                                    @AuthMember MemberInfo memberInfo,
-                                                                    @PathVariable Long groupId) {
-        return null;
+    @PostMapping(value = "/{groupId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ApiResponse.CustomBody<Void>> saveGroupImage(@AuthMember MemberInfo memberInfo,
+                                                                    @PathVariable Long groupId,
+                                                                    @RequestParam MultipartFile file) {
+
+        userGroupService.saveGroupImage(memberInfo, groupId, file);
+        return ApiResponseGenerator.success(HttpStatus.OK);
     }
 
     @GetMapping("/search")

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/CreateGroupReq.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/CreateGroupReq.java
@@ -2,7 +2,6 @@ package com.be.squeak_squeak.group.dto;
 
 public record CreateGroupReq(
         String name,
-        String image,
         String description
 ) {
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/GetGoupMemberListRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/GetGoupMemberListRes.java
@@ -1,0 +1,10 @@
+package com.be.squeak_squeak.group.dto;
+
+import java.util.List;
+
+public record GetGoupMemberListRes(
+        Boolean isOwner,
+        int waitingCount,
+        List<GetGroupMemberRes> groupMemberList
+) {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/GetGroupMemberRes.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/GetGroupMemberRes.java
@@ -1,0 +1,11 @@
+package com.be.squeak_squeak.group.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetGroupMemberRes(
+        Long memberId,
+        String name,
+        String image
+) {
+}

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/UpdateGroupReq.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/dto/UpdateGroupReq.java
@@ -2,7 +2,6 @@ package com.be.squeak_squeak.group.dto;
 
 public record UpdateGroupReq(
         String name,
-        String image,
         String description
 ) {
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
@@ -33,9 +33,8 @@ public class UserGroup {
     @OneToMany(mappedBy = "userGroup", cascade = CascadeType.ALL)
     private List<GroupMember> groupMembers = new ArrayList<>();
 
-    public void updateGroup(String name, String image, String description){
+    public void updateGroup(String name, String description){
         this.name = name;
-        this.image = image;
         this.description = description;
     }
 

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/entity/UserGroup.java
@@ -38,4 +38,8 @@ public class UserGroup {
         this.image = image;
         this.description = description;
     }
+
+    public void updateGroupImage(String image) {
+        this.image = image;
+    }
 }

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -78,20 +78,22 @@ public class UserGroupService {
     }
 
     @Transactional
-    public CreateGroupRes createGroup(CreateGroupReq request, Long memberId) {
+    public CreateGroupRes createGroup(MemberInfo memberInfo, CreateGroupReq request) {
+        Member member = memberRepository.findById(memberInfo.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
         // 초대 코드 생성
         String inviteCode = generateInviteCode();
 
-        Member creator = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-
         UserGroup group = UserGroup.builder()
                 .name(request.name())
-                .image(request.image())
+                .image(null)
                 .description(request.description())
                 .totalMemberCount(1) // 그룹 생성 시 1명 (그룹장)
                 .inviteCode(inviteCode)
                 .build();
+
+//        saveGroupImage(file, group);
 
         // 그룹 저장
         userGroupRepository.save(group);
@@ -99,7 +101,7 @@ public class UserGroupService {
         GroupMember groupMember = GroupMember.builder()
                 .userGroup(group)
                 .status(MemberStatus.OWNER)
-                .member(creator)
+                .member(member)
                 .build();
 
         groupMemberRepository.save(groupMember);
@@ -127,58 +129,22 @@ public class UserGroupService {
     }
 
     @Transactional(readOnly = true)
-    public UpdateGroupRes getUserGroup(Long groupId, Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-
-        UserGroup group = userGroupRepository.findById(groupId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
-
-        // OWNER 권한 확인
-        checkOwnerPermission(group, member);
-
-        return UpdateGroupRes.builder()
-                .id(group.getId())
-                .name(group.getName())
-                .image(group.getImage())
-                .description(group.getDescription())
-                .build();
-    }
-
-    @Transactional
-    public UpdateGroupRes updateGroup(Long groupId, UpdateGroupReq request, Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-
-        UserGroup group = userGroupRepository.findById(groupId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
-
-        // OWNER 권한 확인
-        checkOwnerPermission(group, member);
-
-        group.updateGroup(request.name(), request.image(), request.description());
-
-        return UpdateGroupRes.builder()
-                .id(group.getId())
-                .name(group.getName())
-                .image(group.getImage())
-                .description(group.getDescription())
-                .build();
-    }
-
-    @Transactional(readOnly = true)
-    public List<SearchGroupRes> searchGroup(MemberInfo memberInfo, String type, String keyword) {
+    public UpdateGroupRes getUserGroup(MemberInfo memberInfo, Long groupId) {
         Member member = memberRepository.findById(memberInfo.getId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-        List<UserGroup> userGroupList = userGroupCustomRepository.searchGroup(type, keyword, member.getId());
 
-        return userGroupList.stream()
-                .map(group -> SearchGroupRes.builder()
-                        .id(group.getId())
-                        .image(group.getImage())
-                        .name(group.getName())
-                        .build())
-                .toList();
+        UserGroup group = userGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        // OWNER 권한 확인
+        checkOwnerPermission(group, member);
+
+        return UpdateGroupRes.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .image(group.getImage())
+                .description(group.getDescription())
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -211,10 +177,46 @@ public class UserGroupService {
     }
 
     @Transactional
-    public void saveGroupImage(MemberInfo memberInfo, Long groupId, MultipartFile file) {
+    public UpdateGroupRes updateGroup(MemberInfo memberInfo, Long groupId, UpdateGroupReq request) {
         Member member = memberRepository.findById(memberInfo.getId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
+        UserGroup group = userGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        // OWNER 권한 확인
+        checkOwnerPermission(group, member);
+
+        group.updateGroup(request.name(), request.description());
+//        saveGroupImage(file, group);
+
+        return UpdateGroupRes.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .image(group.getImage())
+                .description(group.getDescription())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<SearchGroupRes> searchGroup(MemberInfo memberInfo, String type, String keyword) {
+        Member member = memberRepository.findById(memberInfo.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        List<UserGroup> userGroupList = userGroupCustomRepository.searchGroup(type, keyword, member.getId());
+
+        return userGroupList.stream()
+                .map(group -> SearchGroupRes.builder()
+                        .id(group.getId())
+                        .image(group.getImage())
+                        .name(group.getName())
+                        .build())
+                .toList();
+    }
+
+    @Transactional
+    public void saveGroupImage(MemberInfo memberInfo, Long groupId, MultipartFile file) {
+        Member member = memberRepository.findById(memberInfo.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
         UserGroup group = userGroupRepository.findById(groupId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
@@ -222,19 +224,16 @@ public class UserGroupService {
         checkOwnerPermission(group, member);
 
         try {
-            // 기존 이미지 삭제 (있다면)
             if (StringUtils.hasText(group.getImage())) {
                 Path oldPath = Paths.get(rootFilePath, group.getImage()).toAbsolutePath();
                 Files.deleteIfExists(oldPath);
             }
 
-            // 새 이미지 저장
             String newImageName = UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
             Path newPath = Paths.get(rootFilePath, newImageName).toAbsolutePath();
             Files.createDirectories(newPath.getParent());
             file.transferTo(newPath.toFile());
 
-            // 그룹 이미지 업데이트
             group.updateGroupImage(newImageName);
             userGroupRepository.save(group);
 
@@ -242,6 +241,31 @@ public class UserGroupService {
             throw new IllegalArgumentException("이미지 저장 중 오류가 발생했습니다.");
         }
     }
+
+//    @Transactional
+//    public void saveGroupImage(MultipartFile file, UserGroup group) {
+//
+//        try {
+//            // 기존 이미지 삭제 (있다면)
+//            if (StringUtils.hasText(group.getImage())) {
+//                Path oldPath = Paths.get(rootFilePath, group.getImage()).toAbsolutePath();
+//                Files.deleteIfExists(oldPath);
+//            }
+//
+//            // 새 이미지 저장
+//            String newImageName = UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
+//            Path newPath = Paths.get(rootFilePath, newImageName).toAbsolutePath();
+//            Files.createDirectories(newPath.getParent());
+//            file.transferTo(newPath.toFile());
+//
+//            // 그룹 이미지 업데이트
+//            group.updateGroupImage(newImageName);
+////            userGroupRepository.save(group);
+//
+//        } catch (IOException e) {
+//            throw new IllegalArgumentException("이미지 저장 중 오류가 발생했습니다.");
+//        }
+//    }
 
     @Transactional
     public void requestJoinGroup(MemberInfo memberInfo, JoinGroupReq joinGroupReq) {

--- a/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
+++ b/squeak-squeak/src/main/java/com/be/squeak_squeak/group/service/UserGroupService.java
@@ -16,12 +16,25 @@ import com.be.squeak_squeak.groupMember.entity.MemberStatus;
 import com.be.squeak_squeak.groupMember.repository.GroupMemberRepository;
 import com.be.squeak_squeak.member.entity.Member;
 import com.be.squeak_squeak.member.repository.MemberRepository;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.UUID;
+
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +43,9 @@ public class UserGroupService {
     private final GroupMemberRepository groupMemberRepository;
     private final MemberRepository memberRepository;
     private final UserGroupCustomRepository userGroupCustomRepository;
+
+    @Value("${file}")
+    private String rootFilePath;
 
     @Transactional(readOnly = true)
     public GetGoupMemberListRes getGroupUsers(Long groupId, MemberInfo memberInfo) {
@@ -165,6 +181,68 @@ public class UserGroupService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public Resource getGroupImage(MemberInfo memberInfo, Long groupId) {
+        Member member = memberRepository.findById(memberInfo.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        UserGroup group = userGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        // Owner만 이미지 조회 가능하도록 처리 가능
+        checkOwnerPermission(group, member);
+
+        if (!StringUtils.hasText(group.getImage())) {
+            throw new IllegalArgumentException("이미지가 존재하지 않습니다.");
+        }
+
+        try {
+            Path imagePath = Paths.get(rootFilePath, group.getImage()).toAbsolutePath();
+            Resource imageResource = new UrlResource(imagePath.toUri());
+
+            if (imageResource.exists() && imageResource.isReadable()) {
+                return imageResource;
+            } else {
+                throw new IllegalArgumentException("이미지를 읽을 수 없습니다.");
+            }
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("이미지 경로가 잘못되었습니다.");
+        }
+    }
+
+    @Transactional
+    public void saveGroupImage(MemberInfo memberInfo, Long groupId, MultipartFile file) {
+        Member member = memberRepository.findById(memberInfo.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+
+        UserGroup group = userGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 그룹입니다."));
+
+        checkOwnerPermission(group, member);
+
+        try {
+            // 기존 이미지 삭제 (있다면)
+            if (StringUtils.hasText(group.getImage())) {
+                Path oldPath = Paths.get(rootFilePath, group.getImage()).toAbsolutePath();
+                Files.deleteIfExists(oldPath);
+            }
+
+            // 새 이미지 저장
+            String newImageName = UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
+            Path newPath = Paths.get(rootFilePath, newImageName).toAbsolutePath();
+            Files.createDirectories(newPath.getParent());
+            file.transferTo(newPath.toFile());
+
+            // 그룹 이미지 업데이트
+            group.updateGroupImage(newImageName);
+            userGroupRepository.save(group);
+
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지 저장 중 오류가 발생했습니다.");
+        }
+    }
+
     @Transactional
     public void requestJoinGroup(MemberInfo memberInfo, JoinGroupReq joinGroupReq) {
         Member member = memberRepository.findById(memberInfo.getId())
@@ -190,7 +268,5 @@ public class UserGroupService {
             throw new IllegalStateException("이 작업은 OWNER만 수행할 수 있습니다.");
         }
     }
-
-
 }
 

--- a/squeak-squeak/src/main/resources/application-local.yml
+++ b/squeak-squeak/src/main/resources/application-local.yml
@@ -48,3 +48,5 @@ google:
   access-token-url: ${GOOGLE_ACCESS_TOKEN_URL}
   member-info-url: ${GOOGLE_MEMBER_INFO_URL}
   redirect-uri: ${GOOGLE_REDIRECT_URI}
+
+file: ${IMAGE_FILE}


### PR DESCRIPTION
## ❗️ 관련 이슈 번호
- Close #45 

## 🚀 작업 내용
- 이미지 저장 및 조회 기능을 구현했습니다.

## 🤔 고민했던 내용
- swagger 환경에서 이미지 파일과 Json Data를 한번에 보낼 수 없는 문제가 발생해서 일단은 두 부분을 모두 나눠서 구현해놓았습니다. 그래서 이부분은 추후에 리팩토링 할 것 같습니다.
- 현재는 1MB 이상의 이미지 파일은 업로드되지 않습니다. 이미지의 용량은 어느정도를 max로 두는게 좋을까요?

## 💬 리뷰 중점사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. -->
